### PR TITLE
CRONAPP-5431 Erro na dependência entre as caixas de seleção a partir …

### DIFF
--- a/js/datasource/datasource.js
+++ b/js/datasource/datasource.js
@@ -2932,7 +2932,12 @@ angular.module('datasourcejs', [])
         var key = keys[i];
         var rowKey = null;
         try {
-          rowKey = eval("rowData."+key);
+          if (Array.isArray(rowData)) {
+            rowKey = eval("rowData[0]."+key);
+          }
+          else {
+            rowKey = eval("rowData."+key);
+          }
         } catch(e){
           //
         }
@@ -3142,6 +3147,16 @@ angular.module('datasourcejs', [])
       var cursor = null;
       var copyObj = null;
 
+      let tryByDataKey = (i) => {
+        var item = this.data[i];
+        for (var key in dataKeys) {
+          if (rowId.hasOwnProperty(key) && rowId[key] === item[key])
+            found = true;
+          else
+            found = false;
+        }
+        return found;
+      };
 
       if (typeof rowId === 'object' && rowId !== null) {
         var dataKeys;
@@ -3151,14 +3166,11 @@ angular.module('datasourcejs', [])
         for (var i = 0; i < this.data.length; i++) {
           if (rowId.__$id && this.data[i].__$id) {
             found = rowId.__$id == this.data[i].__$id;
-          } else {
-            var item = this.data[i];
-            for (var key in dataKeys) {
-              if (rowId.hasOwnProperty(key) && rowId[key] === item[key])
-                found = true;
-              else
-                found = false;
+            if (!found) {
+              found = tryByDataKey(i);
             }
+          } else {
+            found = tryByDataKey(i);
           }
           if (found) {
             cursor = i;


### PR DESCRIPTION
…do filtro

Solução: O mesmo conteudo pode ter um diferente __$id quando vem da busca (findObj) do datasource. Quando o objeto conter o  __$id e não conseguir localizar, tentar obter tb pelo datakey